### PR TITLE
Cypress Tests for Seeding Input Labor Defaults

### DIFF
--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.html
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.html
@@ -53,7 +53,7 @@
             </div>
         </fieldset>   
         <fieldset class="panel panel-default center-block" style="max-width: 500px;" v-show="configToIDMap.labor != 'Hidden'">
-            <legend class="panel-heading" style='background-color: #da4f3f; color: white;font-size: x-large;'>Labor</legend>
+            <legend class="panel-heading" style='background-color: #da4f3f; color: white;font-size: x-large;' data-cy="labor-header">Labor</legend>
             <div class="center-block" style='padding: 12px;text-align:center;font-size: medium; margin-top: 45px;'>
                 <label style='color: #da4f3f' v-show="configToIDMap.labor == 'Required'">*&nbsp;</label>
                 <regex-input data-cy='num-worker-input' :reg-exp="regNumWorker" :default-val="numWorkers" set-type="number" set-min="0" :disabled="submitInProgress" @input-changed="setNewNumWorkers" @match-changed="(newBool) => updateValidMap('validNumWorkers', newBool)"></regex-input>                                                

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
@@ -24,7 +24,7 @@ describe('Test the labor input section', () => {
             .should('have.prop', 'disabled', false)
     })
 
-    it("Checks correct dropdown for selected time unit", () => {
+    it("Checks unit dropdown selection activates correct selected time unit", () => {
         //check minute-input
         cy.get("[data-cy='time-unit'] > [data-cy='dropdown-input']")
             .select("minutes")

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
@@ -1,0 +1,11 @@
+describe('Test the labor input section', () => {
+
+    beforeEach(() => {
+        cy.login('manager1', 'farmdata2')
+        cy.visit('/farm/fd2-field-kit/seedingInput')
+    }) 
+
+    it("Empty", () => {
+
+    })
+})

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
@@ -9,4 +9,13 @@ describe('Test the labor input section', () => {
         cy.get("[data-cy='labor-header']")
             .should("have.text", "Labor")
     })
+     it("Checks Worker input test", () => {
+        cy.get("[data-cy='num-worker-input'] > [data-cy=text-input]")
+            .should('have.value', '')
+        cy.get("[data-cy='num-worker-input'] > [data-cy=text-input]")
+            .should('have.prop', 'disabled', false)
+    })
+
+
+   
 })

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
@@ -5,7 +5,8 @@ describe('Test the labor input section', () => {
         cy.visit('/farm/fd2-field-kit/seedingInput')
     }) 
 
-    it("Empty", () => {
-
+    it("Check header", () => {
+        cy.get("[data-cy='labor-header']")
+            .should("have.text", "Labor")
     })
 })

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
@@ -16,6 +16,12 @@ describe('Test the labor input section', () => {
             .should('have.prop', 'disabled', false)
     })
 
+    it("Checks Time worked input test", () => {
+        cy.get("[data-cy='minute-input'] > [data-cy=text-input]")
+            .should('have.value', '')
+        cy.get("[data-cy='minute-input'] > [data-cy=text-input]")
+            .should('have.prop', 'disabled', false)
+    })
 
    
 })

--- a/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_field_kit/seedingInput/seedingInput.labor.defaults.spec.js
@@ -9,7 +9,8 @@ describe('Test the labor input section', () => {
         cy.get("[data-cy='labor-header']")
             .should("have.text", "Labor")
     })
-     it("Checks Worker input test", () => {
+    
+    it("Checks Worker input test", () => {
         cy.get("[data-cy='num-worker-input'] > [data-cy=text-input]")
             .should('have.value', '')
         cy.get("[data-cy='num-worker-input'] > [data-cy=text-input]")
@@ -48,6 +49,4 @@ describe('Test the labor input section', () => {
         cy.get("[data-cy='time-unit'] > [data-cy='dropdown-input']")
             .find('option:selected').should("have.text", "minutes")
     })
-
-   
 })


### PR DESCRIPTION
__Pull Request Description__

Adds a cypress test file "seedingInput.labor.defaults.spec.js" containing tests for the field kit seeding input's labor section. Tests for the following:

- has correct header.
- has a field for the number of workers that is empty and enabled.
- has a field for the time worked that is empty and enabled.
- has a dropdown for the time units that is enabled.
- the time units dropdown has the options minutes and hours.
- minutes is the default time units for labor data entry.

closes #157 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
