### PR TITLE
Added cy.waitForPage() to dbtest testing examples

### DIFF
--- a/farmdata2/farmdata2_modules/fd2_example/dbtest/dbtest.get.seedings.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_example/dbtest/dbtest.get.seedings.spec.js
@@ -26,6 +26,7 @@ describe("Examples of getting seeding logs via the FarmOSAPI functions in a test
          */
     
         cy.visit("/farm/fd2-example/dbTest")
+        cy.waitForPage()
     })
 
     /**

--- a/farmdata2/farmdata2_modules/fd2_example/dbtest/dbtest.html
+++ b/farmdata2/farmdata2_modules/fd2_example/dbtest/dbtest.html
@@ -1,16 +1,48 @@
-<p>Unlike other sample modules, this sample module does not have content here.
+<div id="dbtest" v-cloak> 
+
+    <p>Unlike other sample modules, this sample module does not have content here.
     Instead, the dbTest sample module consists of a number of <code>.spec.js</code> 
     files that illustrate common patterns used in tests that 
     interact with the database. The contents of those files should be reviewed
     their comments read and studied.  In addition, the tests can be run in 
     the Cypress Test environment.</p>
 
-<p>Each of the files has comments describing what they are doing.  It is recommended
+    <p>Each of the files has comments describing what they are doing.  It is recommended
     to study the files in the order below as later examples may not include comments
     describing things that are documented in an earlier example.</p>
-<ol>
-    <li>dbtest.maps.spec.js</li>: Shows how to get maps (e.g. userToIDMap) from the database and use them in tests.
-    <li>dbtest.get.seedings.js</li>: Shows how to get seeding logs from the database and use them in tests.
-    <li>dbtest.sessionToken.spec.js</li>: Shows how to get a session token needed for operations that modify the database.
-    <li>dbtest.modify.seedings.spec.js</li>: Shows how to create, delete and update seeding logs in the database.
-</ol>
+    <ol>
+        <li>dbtest.maps.spec.js</li>: Shows how to get maps (e.g. userToIDMap) from the database and use them in tests.
+        <li>dbtest.get.seedings.js</li>: Shows how to get seeding logs from the database and use them in tests.
+        <li>dbtest.sessionToken.spec.js</li>: Shows how to get a session token needed for operations that modify the database.
+        <li>dbtest.modify.seedings.spec.js</li>: Shows how to create, delete and update seeding logs in the database.
+    </ol>
+
+    <!-- See maps.html for description of this line.  
+         While not technically needed in this page it is included
+         here so that the example tests are more similar to those
+         that will be created in practice.
+    -->
+    <div data-cy="page-loaded" v-show=false>{{ pageLoaded }}</div>
+</div>
+
+<script>
+new Vue({
+    el: '#dbtest',  // el: must match the id of the <div> for the app above.
+    data: {
+        // Provide easy access to the FarmDat2 variables in vue.
+        userID: fd2UserID,
+        userName: fd2UserName,
+
+        createdCount: 0,  // used in created and pageLoaded
+    },
+    computed: {
+        pageLoaded() {
+            // Check here that the correct number of API calls have completed.
+            return this.createdCount == 1
+        },
+    },
+    created() {
+        this.createdCount++
+    }
+})
+</script>

--- a/farmdata2/farmdata2_modules/fd2_example/dbtest/dbtest.maps.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_example/dbtest/dbtest.maps.spec.js
@@ -72,6 +72,14 @@ describe('Example of getting a map to via the FarmOSAPI functions in a test', ()
         // Visit the page that will be tested. 
         cy.visit("/farm/fd2-example/dbTest")
 
+                /*
+         * Almost always the page being visited will load maps and other
+         * content in its created() hook.  If the page follows the pattern
+         * used in FarmData2 pages (see Maps.html for an example with explanation)
+         * then this causes the tests to wait here until the entire page and
+         * all of its data is loaded before continuing.
+         */
+        cy.waitForPage()
     })
 
     /**

--- a/farmdata2/farmdata2_modules/fd2_example/dbtest/dbtest.modify.seedings.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_example/dbtest/dbtest.modify.seedings.spec.js
@@ -30,6 +30,7 @@ describe('Example of creating and deleting seeding logs in a test', () => {
         })
 
         cy.visit("/farm/fd2-example/dbTest")
+        cy.waitForPage()
     })
 
     /**
@@ -64,7 +65,12 @@ describe('Example of creating and deleting seeding logs in a test', () => {
          * Do your testing in this it.
          */
         it("Do your test using the new log(s) here.", () => {
-            expect(true).to.equal(false)
+            /*
+             * This test can be changed to expect(true).to.equal(true)
+             * in order to check that the record is still deleted by the
+             * afterEach() even if the test fails.
+             */
+            expect(true).to.equal(true)
         })
 
         /**

--- a/farmdata2/farmdata2_modules/fd2_example/dbtest/dbtest.sessionToken.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_example/dbtest/dbtest.sessionToken.spec.js
@@ -48,6 +48,7 @@ describe("Illustration of how to get a session token.", () => {
 
         // Visit the page that will be tested. 
         cy.visit("/farm/fd2-example/dbTest")
+        cy.waitForPage()
     })
 
     /**


### PR DESCRIPTION
__Pull Request Description__

Added the `cy.waitForPage()` pattern to the the `dbtest` examples so that they are closer to real typical use cases.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
