### PR TITLE
Updated documentation to account for extra blank spaces added in CustomTableComponent

### DIFF
--- a/farmdata2/farmdata2_modules/resources/CustomTableComponent.js
+++ b/farmdata2/farmdata2_modules/resources/CustomTableComponent.js
@@ -30,8 +30,8 @@ catch(err) {
  * <tr><td>ri-cbutton</td>           <td>The td element containing the checkbox for the ith table row if it appears. i=0,1,2...</td></tr>
  * <tr><td>ri-cbuttonCheckbox</td>   <td>The checkbox element for the ith table row if custom buttons or deleting is enabled, i=0,1,2,...</td></tr>
  * <tr><td>ri</td>                   <td>The tr element for the ith table row, i=0,1,2,...</td></tr>
- * <tr><td>td-ricj</td>              <td>The td element in the ith row and jth column, i,j=0,1,2...</td></tr>
- * <tr><td>ri-*</td>                 <td>The div for plain text in the ith row and the indicated column, * is replaced by the column header. i=0,1,2....</td></tr>
+ * <tr><td>td-ricj</td>              <td>The td element in the ith row and jth column, i,j=0,1,2... Note: using td-ricj in cypress tests will cause five additional whitespaces to appear in the td element retrieved. To fix this issue, make sure to use contains.text instead of have.text</td></tr>
+ * <tr><td>ri-*</td>                 <td>The div for plain text in the ith row and the indicated column, * is replaced by the column header. i=0,1,2.... Note: using this cy attribute circumvents the issue mentioned in the line above since it does not add five extra whitespaces to the td element. Therefore, it is fine to use have.text</td></tr>
  * <tr><td>ri-*-input</td>           <td>The input element ith row and the indicated column in edit mode, * is replaced by the column header. i=0,1,2....</td></tr>
  * <tr><td>ri-edit-button</td>       <td>The edit button in the ith row, i=0,1,2....</td></tr>
  * <tr><td>ri-save-button</td>       <td>The save button in the ith row, i=0,1,2....</td></tr>


### PR DESCRIPTION
__Pull Request Description__

We have found that the blank space bug seems to be happening from outside of the FarmData2 code, so the best solution seems to be to use ri-<column name> when possible instead of ricj. When td-ricj needs to be used, the best option seems to be to use contains.text instead of have.text.

We have updated the documentation of the CustomTableComponent accordingly.

Closes #215 

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
