### PR TITLE
Created Tests for Issue#10

### DIFF
--- a/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.defaults.spec.js
@@ -1,0 +1,39 @@
+/**
+ * Tests the default state of the Seeding Report page in the BarnKit module.
+ * Ensures correct UI elements appear and that default dates are properly set.
+ */
+import dayjs from 'dayjs'
+
+describe('Test the Seeding Report Default View', () => {
+  beforeEach(() => {
+    cy.login("manager1", "farmdata2")
+    cy.visit("/farm/fd2-barn-kit/seedingReport");
+  });
+
+  it('displays correct defaults', () => {
+    cy.contains('h1', "Seeding report");
+    cy.contains('label', "Set Dates");
+    cy.get('button').contains("Generate Report").should('be.enabled');
+
+
+  // Check default start and end dates
+  const expectedStart = dayjs().startOf('year').format('YYYY-MM-DD').toString()
+  const expectedEnd = dayjs().format('YYYY-MM-DD').toString()
+
+  cy.get('[data-cy="date-range-selection"]').within(() => {
+    cy.get('input[type="date"]').eq(0).should('have.value', expectedStart)  //Test Start Date
+    cy.get('input[type="date"]').eq(1).should('have.value', expectedEnd)   //Test End Date
+
+  });
+
+
+
+  // Report should NOT be visible by default
+  cy.get('[data-cy="filters-panel"]').should('not.exist');
+  cy.get('[data-cy="report-table"]').should('not.exist');
+  cy.get('[data-cy="no-logs-message"]').should('not.exist');
+  cy.get('[data-cy="loader"]').should('not.exist');
+});
+
+
+});

--- a/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.defaults.spec.js
+++ b/farmdata2/farmdata2_modules/fd2_barn_kit/seedingReport/seedingReport.defaults.spec.js
@@ -11,8 +11,8 @@ describe('Test the Seeding Report Default View', () => {
   });
 
   it('displays correct defaults', () => {
-    cy.contains('h1', "Seeding report");
-    cy.contains('label', "Set Dates");
+    cy.contains('h1', "Seeding Report");
+    cy.contains('legend', "Set Dates");
     cy.get('button').contains("Generate Report").should('be.enabled');
 
 


### PR DESCRIPTION
__Pull Request Description__

Address #10 
Tested the default values in the SeedingReport
 - page contains the header "Seeding Report"

- page contains a section labeled "Set Dates"

- button has the label "Generate Report" and is enabled.

- default start date is the first day of the current year.

- default end date is the current date.

- the remainder of the report is not visible or does not exist.

---
__Licensing Certification__

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request __I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)__ for its contents.
